### PR TITLE
Structured error handling in library crates lint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5274,6 +5274,7 @@ Released 2018-09-13
 [`let_underscore_untyped`]: https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_untyped
 [`let_unit_value`]: https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value
 [`let_with_type_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#let_with_type_underscore
+[`library_crates_structured_errors`]: https://rust-lang.github.io/rust-clippy/master/index.html#library_crates_structured_errors
 [`lines_filter_map_ok`]: https://rust-lang.github.io/rust-clippy/master/index.html#lines_filter_map_ok
 [`linkedlist`]: https://rust-lang.github.io/rust-clippy/master/index.html#linkedlist
 [`little_endian_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#little_endian_bytes

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -253,6 +253,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::let_underscore::LET_UNDERSCORE_MUST_USE_INFO,
     crate::let_underscore::LET_UNDERSCORE_UNTYPED_INFO,
     crate::let_with_type_underscore::LET_WITH_TYPE_UNDERSCORE_INFO,
+    crate::library_crates_structured_errors::LIBRARY_CRATES_STRUCTURED_ERRORS_INFO,
     crate::lifetimes::EXTRA_UNUSED_LIFETIMES_INFO,
     crate::lifetimes::NEEDLESS_LIFETIMES_INFO,
     crate::lines_filter_map_ok::LINES_FILTER_MAP_OK_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -181,6 +181,7 @@ mod len_zero;
 mod let_if_seq;
 mod let_underscore;
 mod let_with_type_underscore;
+mod library_crates_structured_errors;
 mod lifetimes;
 mod lines_filter_map_ok;
 mod literal_representation;
@@ -1092,6 +1093,8 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(move |_| {
         Box::new(thread_local_initializer_can_be_made_const::ThreadLocalInitializerCanBeMadeConst::new(msrv()))
     });
+    store
+        .register_late_pass(move |_| Box::<library_crates_structured_errors::LibraryCratesStructuredErrors>::default());
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/library_crates_structured_errors.rs
+++ b/clippy_lints/src/library_crates_structured_errors.rs
@@ -1,0 +1,134 @@
+use clippy_utils::diagnostics::span_lint_and_note;
+use clippy_utils::match_def_path;
+use clippy_utils::ty::{is_type_lang_item, result_err_ty};
+use rustc_hir::intravisit::FnKind;
+use rustc_hir::{Body, FnDecl, LangItem};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
+use rustc_middle::ty::{ExistentialPredicate, Ty};
+use rustc_session::config::CrateType;
+use rustc_session::impl_lint_pass;
+use rustc_span::def_id::LocalDefId;
+use rustc_span::{sym, Span};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Finds usages of unstructured error types in library crates.
+    ///
+    /// ### Why is this bad?
+    /// Libraries should use structured error types to allow users to
+    /// match on different error cases.
+    ///
+    /// ### Known problems
+    /// This only detects certain kinds of unstructured error types,
+    /// not all of them.
+    ///
+    /// ### Example
+    /// Before:
+    /// ```no_run
+    /// use std::error::Error;
+    /// fn foo() -> Result<(), Box<dyn Error>> {
+    ///    todo!()
+    /// }
+    /// ```
+    ///
+    /// After:
+    /// ```no_run
+    /// struct MyError;
+    /// fn foo() -> Result<(), MyError> {
+    ///   todo!()
+    /// }
+    /// ```
+    #[clippy::version = "1.77.0"]
+    pub LIBRARY_CRATES_STRUCTURED_ERRORS,
+    restriction,
+    "library crates that use unstructured error types"
+}
+
+#[derive(Default)]
+pub struct LibraryCratesStructuredErrors {
+    is_library_crate: Option<bool>,
+}
+
+impl_lint_pass!(LibraryCratesStructuredErrors => [LIBRARY_CRATES_STRUCTURED_ERRORS]);
+
+fn is_overly_generic_error_type(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
+    if is_type_lang_item(cx, ty, LangItem::String) {
+        return true;
+    }
+    if is_type_lang_item(cx, ty, LangItem::OwnedBox) {
+        let inner = ty.boxed_ty();
+        if let ty::Dynamic(predicates, _, _) = inner.kind() {
+            if predicates.iter().any(|predicate| {
+                if let ExistentialPredicate::Trait(trait_) = predicate.skip_binder() {
+                    cx.tcx.is_diagnostic_item(sym::Error, trait_.def_id)
+                } else {
+                    false
+                }
+            }) {
+                return true;
+            }
+        }
+    }
+    if match ty.kind() {
+        ty::Adt(adt, _) => {
+            match_def_path(cx, adt.did(), &["anyhow", "Error"]) || match_def_path(cx, adt.did(), &["eyre", "Report"])
+        },
+        _ => false,
+    } {
+        return true;
+    }
+    false
+}
+
+fn is_library_crate(cx: &LateContext<'_>) -> bool {
+    cx.tcx.crate_types().iter().any(|t: &CrateType| {
+        matches!(
+            t,
+            CrateType::Cdylib | CrateType::Dylib | CrateType::Rlib | CrateType::ProcMacro | CrateType::Staticlib
+        )
+    })
+}
+
+impl<'tcx> LateLintPass<'tcx> for LibraryCratesStructuredErrors {
+    fn check_crate(&mut self, cx: &LateContext<'tcx>) {
+        if is_library_crate(cx) {
+            self.is_library_crate = Some(true);
+        } else {
+            self.is_library_crate = Some(false);
+        }
+    }
+
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        fn_kind: FnKind<'tcx>,
+        fn_: &'tcx FnDecl<'tcx>,
+        _: &'tcx Body<'tcx>,
+        span: Span,
+        local_def_id: LocalDefId,
+    ) {
+        if !self
+            .is_library_crate
+            .expect("Should have been initialized in check_crate")
+        {
+            return;
+        }
+        //We are looking for functions that return anyhow::Result or
+        // Result<_, Box<dyn Error>> or Result<_, String>
+        if let FnKind::Method(_, _) | FnKind::ItemFn(_, _, _) = fn_kind {
+            if let Some((hir_ty, err_ty)) = result_err_ty(cx, fn_, local_def_id, span)
+                && is_overly_generic_error_type(cx, err_ty)
+            {
+                span_lint_and_note(
+                    cx,
+                    LIBRARY_CRATES_STRUCTURED_ERRORS,
+                    hir_ty.span,
+                    "this is an unstructured error type",
+                    None,
+                    "try using an error enum",
+                );
+            }
+        }
+    }
+}

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/binary_uses_anyhow/Cargo.toml
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/binary_uses_anyhow/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "binary_uses_anyhow"
+version = "0.1.0"
+edition = "2021"
+publish = false
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/binary_uses_anyhow/src/main.rs
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/binary_uses_anyhow/src/main.rs
@@ -1,0 +1,14 @@
+#![warn(clippy::library_crates_structured_errors)]
+
+pub fn uses_anyhow_error_directly() -> Result<(), anyhow::Error> {
+    todo!()
+}
+
+pub fn uses_anyhow_error_indirectly() -> anyhow::Result<()> {
+    uses_anyhow_error_directly()?;
+    Ok(())
+}
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/string_and_boxed_error/Cargo.stderr
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/string_and_boxed_error/Cargo.stderr
@@ -1,0 +1,19 @@
+error: this is an unstructured error type
+ --> src/lib.rs:5:17
+  |
+5 | pub fn foo() -> Result<(), String> {
+  |                 ^^^^^^^^^^^^^^^^^^
+  |
+  = note: try using an error enum
+  = note: `-D clippy::library-crates-structured-errors` implied by `-D warnings`
+  = help: to override `-D warnings` add `#[allow(clippy::library_crates_structured_errors)]`
+
+error: this is an unstructured error type
+ --> src/lib.rs:9:17
+  |
+9 | pub fn bar() -> Result<(), Box<dyn Error>> {
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: try using an error enum
+
+error: could not compile `string_and_boxed_error` (lib) due to 2 previous errors

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/string_and_boxed_error/Cargo.toml
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/string_and_boxed_error/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "string_and_boxed_error"
+version = "0.1.0"
+edition = "2021"
+publish = false
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/string_and_boxed_error/src/lib.rs
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/string_and_boxed_error/src/lib.rs
@@ -1,0 +1,11 @@
+#![warn(clippy::library_crates_structured_errors)]
+
+use std::error::Error;
+
+pub fn foo() -> Result<(), String> {
+    todo!()
+}
+
+pub fn bar() -> Result<(), Box<dyn Error>> {
+    todo!()
+}

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_anyhow/Cargo.stderr
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_anyhow/Cargo.stderr
@@ -1,0 +1,19 @@
+error: this is an unstructured error type
+ --> src/lib.rs:3:40
+  |
+3 | pub fn uses_anyhow_error_directly() -> Result<(), anyhow::Error> {
+  |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: try using an error enum
+  = note: `-D clippy::library-crates-structured-errors` implied by `-D warnings`
+  = help: to override `-D warnings` add `#[allow(clippy::library_crates_structured_errors)]`
+
+error: this is an unstructured error type
+ --> src/lib.rs:7:42
+  |
+7 | pub fn uses_anyhow_error_indirectly() -> anyhow::Result<()> {
+  |                                          ^^^^^^^^^^^^^^^^^^
+  |
+  = note: try using an error enum
+
+error: could not compile `uses_anyhow` (lib) due to 2 previous errors

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_anyhow/Cargo.toml
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_anyhow/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "uses_anyhow"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+
+[dependencies]
+anyhow = "1"

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_anyhow/src/lib.rs
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_anyhow/src/lib.rs
@@ -1,0 +1,10 @@
+#![warn(clippy::library_crates_structured_errors)]
+
+pub fn uses_anyhow_error_directly() -> Result<(), anyhow::Error> {
+    todo!()
+}
+
+pub fn uses_anyhow_error_indirectly() -> anyhow::Result<()> {
+    uses_anyhow_error_directly()?;
+    Ok(())
+}

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_eyre/Cargo.stderr
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_eyre/Cargo.stderr
@@ -1,0 +1,19 @@
+error: this is an unstructured error type
+ --> src/lib.rs:3:38
+  |
+3 | pub fn uses_eyre_error_directly() -> Result<(), eyre::Report> {
+  |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: try using an error enum
+  = note: `-D clippy::library-crates-structured-errors` implied by `-D warnings`
+  = help: to override `-D warnings` add `#[allow(clippy::library_crates_structured_errors)]`
+
+error: this is an unstructured error type
+ --> src/lib.rs:7:40
+  |
+7 | pub fn uses_eyre_error_indirectly() -> eyre::Result<()> {
+  |                                        ^^^^^^^^^^^^^^^^
+  |
+  = note: try using an error enum
+
+error: could not compile `uses_eyre` (lib) due to 2 previous errors

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_eyre/Cargo.toml
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_eyre/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uses_eyre"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+eyre = "0.6.11"

--- a/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_eyre/src/lib.rs
+++ b/tests/ui-cargo/library_crate_uses_unstructured_errors/uses_eyre/src/lib.rs
@@ -1,0 +1,10 @@
+#![warn(clippy::library_crates_structured_errors)]
+
+pub fn uses_eyre_error_directly() -> Result<(), eyre::Report> {
+    todo!()
+}
+
+pub fn uses_eyre_error_indirectly() -> eyre::Result<()> {
+    uses_eyre_error_directly()?;
+    Ok(())
+}


### PR DESCRIPTION
This lint helps with enforcing discipline around the use of strcutured errors in library crates. Libraries should provide errors that can be matched on, and as a result shouldn't use anyhow/Box<dyn Error> or similar such approaches.


changelog: [`library_crates_structured_errors`]: enforces that library crates use structured error types
